### PR TITLE
Fix invalid key code handling

### DIFF
--- a/src/main/java/humanbot/MainApp.java
+++ b/src/main/java/humanbot/MainApp.java
@@ -97,7 +97,7 @@ public class MainApp {
     private static void typeSnippet(String text) {
         for (char c : text.toCharArray()) {
             int keyCode = KeyEvent.getExtendedKeyCodeForChar(c);
-            if (KeyEvent.CHAR_UNDEFINED == keyCode) {
+            if (keyCode == KeyEvent.VK_UNDEFINED) {
                 continue;
             }
             robot.keyPress(keyCode);


### PR DESCRIPTION
## Summary
- ignore undefined key codes when typing snippets

## Testing
- `mvn -q package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d352535908327bbc5cdd5443b7b79